### PR TITLE
Fix logout handler to respect request host

### DIFF
--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,7 +1,16 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-export async function POST() {
-  const res = NextResponse.redirect(new URL("/", "http://localhost:3000"));
-  res.cookies.set("session", "", { httpOnly: true, sameSite: "lax", path: "/", maxAge: 0 });
+export async function POST(request: NextRequest) {
+  const url = new URL("/", request.url);
+  const res = NextResponse.redirect(url);
+  res.cookies.set({
+    name: "session",
+    value: "",
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+    domain: url.hostname,
+  });
   return res;
 }


### PR DESCRIPTION
## Summary
- update the logout endpoint to build its redirect URL from the incoming request
- clear the session cookie using the request host so the cookie is removed on the correct domain and path

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9cbffe9c832c9223376d8609c0df