### PR TITLE
Replace custom UI with shadcn components

### DIFF
--- a/app/(panel)/_components/BackBar.tsx
+++ b/app/(panel)/_components/BackBar.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useRouter, usePathname } from "next/navigation";
-import Link from "next/link";
-import { signOutAction } from "@/app/(panel)/_actions/logout";
+import { useRouter, usePathname } from "next/navigation"
+import Link from "next/link"
+import { signOutAction } from "@/app/(panel)/_actions/logout"
+import { Button } from "@/components/ui/button"
 
 type Props = {
   homeHref: string;     // np. "/panel-admin" albo "/panel-montazysty"
@@ -10,39 +11,33 @@ type Props = {
 };
 
 export default function BackBar({ homeHref, homeLabel }: Props) {
-  const router = useRouter();
-  const pathname = usePathname();
+  const router = useRouter()
+  const pathname = usePathname()
 
   return (
     <header className="sticky top-0 z-10 border-b bg-white/70 backdrop-blur">
-      <div className="mx-auto max-w-6xl flex items-center gap-3 p-3">
-        <button
-          onClick={() => router.back()}
-          className="rounded-md border px-3 py-1.5 hover:bg-neutral-50"
-        >
+      <div className="mx-auto flex max-w-6xl items-center gap-3 p-3">
+        <Button type="button" variant="outline" size="sm" onClick={() => router.back()}>
           ← Wstecz
-        </button>
+        </Button>
 
-        <Link
-          href={homeHref}
-          className="rounded-md border px-3 py-1.5 hover:bg-neutral-50"
-        >
-          {homeLabel}
-        </Link>
+        <Button asChild variant="outline" size="sm">
+          <Link href={homeHref}>{homeLabel}</Link>
+        </Button>
 
         <span className="ml-auto text-sm text-neutral-500">{pathname}</span>
 
         <form
           action={async () => {
-            await signOutAction();
-            router.replace("/");
+            await signOutAction()
+            router.replace("/")
           }}
         >
-          <button className="rounded-md border px-3 py-1.5 hover:bg-neutral-50">
+          <Button variant="outline" size="sm">
             Wyloguj
-          </button>
+          </Button>
         </form>
       </div>
     </header>
-  );
+  )
 }

--- a/app/(panel)/error.tsx
+++ b/app/(panel)/error.tsx
@@ -1,39 +1,38 @@
-"use client";
+"use client"
 
-import { useEffect } from "react";
+import { useEffect } from "react"
+import { Button } from "@/components/ui/button"
 
 export default function PanelError(
   { error, reset }: { error: Error & { digest?: string }; reset: () => void }
 ) {
   useEffect(() => {
-    console.error(error);
-  }, [error]);
+    console.error(error)
+  }, [error])
 
   return (
-    <main className="p-8 space-y-3">
+    <main className="space-y-3 p-8">
       <h1 className="text-2xl font-semibold">Coś poszło nie tak</h1>
       <p className="text-sm text-neutral-600">
         Spróbuj ponownie. Jeśli błąd będzie wracał, daj znać administratorowi.
       </p>
 
       <div className="mt-2 flex gap-2">
-        <button
-          onClick={() => reset()}
-          className="rounded-md border px-3 py-1.5 hover:bg-neutral-50"
-        >
+        <Button variant="outline" size="sm" onClick={() => reset()}>
           Spróbuj ponownie
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
           onClick={() => (window.location.href = "/")}
-          className="rounded-md border px-3 py-1.5 hover:bg-neutral-50"
         >
           Wróć do strony głównej
-        </button>
+        </Button>
       </div>
 
       {error?.digest && (
         <p className="text-xs text-neutral-400">Kod błędu: {error.digest}</p>
       )}
     </main>
-  );
+  )
 }

--- a/app/(panel)/panel-admin/uzytkownicy/AddUserForm.tsx
+++ b/app/(panel)/panel-admin/uzytkownicy/AddUserForm.tsx
@@ -1,62 +1,92 @@
-"use client";
+"use client"
 
-import { useState, useTransition } from "react";
-import { createUserAction } from "./actions";
+import { useState, useTransition } from "react"
+import { createUserAction } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
 export default function AddUserForm() {
-  const [msg, setMsg] = useState<string | null>(null);
-  const [pending, startTransition] = useTransition();
+  const [msg, setMsg] = useState<string | null>(null)
+  const [role, setRole] = useState("MONTAZYSTA")
+  const [pending, startTransition] = useTransition()
 
   return (
     <form
       action={async (fd) => {
-        setMsg(null);
+        setMsg(null)
         startTransition(async () => {
-          const res = await createUserAction(fd);
-          setMsg(res.error ?? (res.ok ? "Użytkownik dodany." : null));
-        });
+          fd.set("role", role)
+          const res = await createUserAction(fd)
+          setMsg(res.error ?? (res.ok ? "Użytkownik dodany." : null))
+        })
       }}
-      className="space-y-4 max-w-md rounded-lg border p-4"
+      className="max-w-md space-y-4 rounded-lg border p-4"
     >
       <h2 className="text-lg font-medium">Dodaj użytkownika</h2>
 
-      <div className="grid gap-1">
-        <label className="text-sm">E-mail</label>
-        <input name="email" type="email" required className="w-full rounded-md border px-3 py-2" placeholder="user@primepodloga.pl" />
+      <div className="grid gap-2">
+        <Label htmlFor="user-email" className="text-sm">
+          E-mail
+        </Label>
+        <Input
+          id="user-email"
+          name="email"
+          type="email"
+          required
+          placeholder="user@primepodloga.pl"
+        />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Imię (opcjonalnie)</label>
-        <input name="firstName" type="text" className="w-full rounded-md border px-3 py-2" />
+      <div className="grid gap-2">
+        <Label htmlFor="user-first-name" className="text-sm">
+          Imię (opcjonalnie)
+        </Label>
+        <Input id="user-first-name" name="firstName" type="text" />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Rola</label>
-        <select name="role" className="w-full rounded-md border px-3 py-2">
-          <option value="MONTAZYSTA">MONTAŻYSTA</option>
-          <option value="ADMIN">ADMIN</option>
-        </select>
+      <div className="grid gap-2">
+        <Label htmlFor="user-role" className="text-sm">
+          Rola
+        </Label>
+        <Select value={role} onValueChange={setRole}>
+          <SelectTrigger id="user-role">
+            <SelectValue placeholder="Wybierz rolę" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="MONTAZYSTA">MONTAŻYSTA</SelectItem>
+            <SelectItem value="ADMIN">ADMIN</SelectItem>
+          </SelectContent>
+        </Select>
+        <input type="hidden" name="role" value={role} />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Hasło</label>
-        <input name="password" type="password" required minLength={8} className="w-full rounded-md border px-3 py-2" />
+      <div className="grid gap-2">
+        <Label htmlFor="user-password" className="text-sm">
+          Hasło
+        </Label>
+        <Input id="user-password" name="password" type="password" required minLength={8} />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Powtórz hasło</label>
-        <input name="password2" type="password" required minLength={8} className="w-full rounded-md border px-3 py-2" />
+      <div className="grid gap-2">
+        <Label htmlFor="user-password2" className="text-sm">
+          Powtórz hasło
+        </Label>
+        <Input id="user-password2" name="password2" type="password" required minLength={8} />
       </div>
 
-      <button
-        type="submit"
-        disabled={pending}
-        className="rounded-md border px-4 py-2 font-medium hover:bg-neutral-50 disabled:opacity-60"
-      >
+      <Button type="submit" disabled={pending} className="font-medium">
         {pending ? "Dodaję..." : "Dodaj"}
-      </button>
+      </Button>
 
-      {msg && <p className="text-sm text-red-600">{msg}</p>}
+      {msg && <p className="text-sm text-destructive">{msg}</p>}
     </form>
-  );
+  )
 }

--- a/app/(panel)/panel-admin/uzytkownicy/UserRowActions.tsx
+++ b/app/(panel)/panel-admin/uzytkownicy/UserRowActions.tsx
@@ -1,8 +1,18 @@
-"use client";
+"use client"
 
-import { useState, useTransition } from "react";
-import { updateUserAction, toggleActiveAction, resetPasswordAction } from "./actions";
-import type { Role } from "@prisma/client";
+import { useState, useTransition } from "react"
+import { updateUserAction, toggleActiveAction, resetPasswordAction } from "./actions"
+import type { Role } from "@prisma/client"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
 export default function UserRowActions(props: {
   id: number;
@@ -10,55 +20,74 @@ export default function UserRowActions(props: {
   role: Role;
   isActive: boolean;
 }) {
-  const [msg, setMsg] = useState<string | null>(null);
-  const [pending, start] = useTransition();
+  const [msg, setMsg] = useState<string | null>(null)
+  const [role, setRole] = useState<Role>(props.role)
+  const [pending, start] = useTransition()
 
   return (
-    <td className="px-3 py-2 space-y-2">
+    <td className="space-y-2 px-3 py-2">
       {/* Edycja imienia + roli */}
       <form
         className="flex items-center gap-2"
         action={(fd) =>
           start(async () => {
-            setMsg(null);
-            fd.set("id", String(props.id));
-            const res = await updateUserAction(fd);
-            setMsg(res.error ?? (res.ok ? "Zapisano." : null));
+            setMsg(null)
+            fd.set("id", String(props.id))
+            fd.set("role", role)
+            const res = await updateUserAction(fd)
+            setMsg(res.error ?? (res.ok ? "Zapisano." : null))
           })
         }
       >
         <input type="hidden" name="id" value={props.id} />
-        <input
-          name="firstName"
-          defaultValue={props.firstName ?? ""}
-          placeholder="Imię"
-          className="rounded-md border px-2 py-1"
-        />
-        <select name="role" defaultValue={props.role} className="rounded-md border px-2 py-1">
-          <option value="MONTAZYSTA">MONTAŻYSTA</option>
-          <option value="ADMIN">ADMIN</option>
-        </select>
-        <button disabled={pending} className="rounded-md border px-2 py-1 hover:bg-neutral-50 disabled:opacity-60">
+        <div className="grid gap-1">
+          <Label className="sr-only" htmlFor={`user-first-name-${props.id}`}>
+            Imię
+          </Label>
+          <Input
+            id={`user-first-name-${props.id}`}
+            name="firstName"
+            defaultValue={props.firstName ?? ""}
+            placeholder="Imię"
+            className="h-9 w-32"
+          />
+        </div>
+        <div className="grid gap-1">
+          <Label className="sr-only" htmlFor={`user-role-${props.id}`}>
+            Rola
+          </Label>
+          <Select value={role} onValueChange={(value) => setRole(value as Role)}>
+            <SelectTrigger id={`user-role-${props.id}`} className="h-9 w-40">
+              <SelectValue placeholder="Rola" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="MONTAZYSTA">MONTAŻYSTA</SelectItem>
+              <SelectItem value="ADMIN">ADMIN</SelectItem>
+            </SelectContent>
+          </Select>
+          <input type="hidden" name="role" value={role} />
+        </div>
+        <Button variant="outline" size="sm" disabled={pending}>
           Zapisz
-        </button>
+        </Button>
       </form>
 
       {/* Aktywacja/dezaktywacja */}
       <form
         action={() =>
           start(async () => {
-            setMsg(null);
-            const fd = new FormData();
-            fd.set("id", String(props.id));
-            fd.set("active", String(props.isActive));
-            const res = await toggleActiveAction(fd);
-            setMsg(res.error ?? (res.ok ? (props.isActive ? "Dezaktywowano." : "Aktywowano.") : null));
+            setMsg(null)
+            const fd = new FormData()
+            fd.set("id", String(props.id))
+            fd.set("active", String(props.isActive))
+            const res = await toggleActiveAction(fd)
+            setMsg(res.error ?? (res.ok ? (props.isActive ? "Dezaktywowano." : "Aktywowano.") : null))
           })
         }
       >
-        <button disabled={pending} className="rounded-md border px-2 py-1 hover:bg-neutral-50 disabled:opacity-60">
+        <Button variant="outline" size="sm" disabled={pending}>
           {props.isActive ? "Dezaktywuj" : "Aktywuj"}
-        </button>
+        </Button>
       </form>
 
       {/* Reset hasła */}
@@ -66,21 +95,45 @@ export default function UserRowActions(props: {
         className="flex gap-2"
         action={(fd) =>
           start(async () => {
-            setMsg(null);
-            fd.set("id", String(props.id));
-            const res = await resetPasswordAction(fd);
-            setMsg(res.error ?? (res.ok ? "Hasło ustawione." : null));
+            setMsg(null)
+            fd.set("id", String(props.id))
+            const res = await resetPasswordAction(fd)
+            setMsg(res.error ?? (res.ok ? "Hasło ustawione." : null))
           })
         }
       >
-        <input name="password" type="password" placeholder="Nowe hasło" minLength={8} className="rounded-md border px-2 py-1" />
-        <input name="password2" type="password" placeholder="Powtórz" minLength={8} className="rounded-md border px-2 py-1" />
-        <button disabled={pending} className="rounded-md border px-2 py-1 hover:bg-neutral-50 disabled:opacity-60">
+        <div className="grid gap-1">
+          <Label className="sr-only" htmlFor={`reset-password-${props.id}`}>
+            Nowe hasło
+          </Label>
+          <Input
+            id={`reset-password-${props.id}`}
+            name="password"
+            type="password"
+            placeholder="Nowe hasło"
+            minLength={8}
+            className="h-9"
+          />
+        </div>
+        <div className="grid gap-1">
+          <Label className="sr-only" htmlFor={`reset-password2-${props.id}`}>
+            Powtórz hasło
+          </Label>
+          <Input
+            id={`reset-password2-${props.id}`}
+            name="password2"
+            type="password"
+            placeholder="Powtórz"
+            minLength={8}
+            className="h-9"
+          />
+        </div>
+        <Button variant="outline" size="sm" disabled={pending}>
           Reset
-        </button>
+        </Button>
       </form>
 
-      {msg && <p className="text-xs text-red-600">{msg}</p>}
+      {msg && <p className="text-xs text-destructive">{msg}</p>}
     </td>
-  );
+  )
 }

--- a/app/(panel)/panel-admin/uzytkownicy/page.tsx
+++ b/app/(panel)/panel-admin/uzytkownicy/page.tsx
@@ -1,54 +1,61 @@
-// app/(panel)/panel-admin/uzytkownicy/page.tsx
-import { getSession } from "@/lib/session";
-import { redirect } from "next/navigation";
-import prisma from "@/lib/prisma";
-import { Role } from "@prisma/client";
-import AddUserForm from "./AddUserForm";
-import UserRowActions from "./UserRowActions";
+import { getSession } from "@/lib/session"
+import { redirect } from "next/navigation"
+import prisma from "@/lib/prisma"
+import { Role } from "@prisma/client"
+import AddUserForm from "./AddUserForm"
+import UserRowActions from "./UserRowActions"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 
 export const metadata = { title: "Użytkownicy — Admin" };
 
 export default async function UsersPage() {
-  const s = await getSession();
-  if (!s || s.user.role !== Role.ADMIN) redirect("/");
+  const s = await getSession()
+  if (!s || s.user.role !== Role.ADMIN) redirect("/")
 
   const users = await prisma.user.findMany({
     orderBy: { id: "desc" },
     select: { id: true, email: true, firstName: true, role: true, isActive: true },
-  });
+  })
 
   return (
-    <main className="p-8 space-y-8">
+    <main className="space-y-8 p-8">
       <h1 className="text-2xl font-semibold">Użytkownicy</h1>
 
-      <div className="overflow-x-auto rounded-lg border">
-        <table className="w-full text-sm">
-          <thead className="bg-neutral-50">
-            <tr>
-              <th className="px-3 py-2 text-left">ID</th>
-              <th className="px-3 py-2 text-left">E-mail</th>
-              <th className="px-3 py-2 text-left">Edycja</th>
-              <th className="px-3 py-2 text-left">Rola</th>
-              <th className="px-3 py-2 text-left">Aktywny</th>
-              <th className="px-3 py-2 text-left">Akcje</th>
-            </tr>
-          </thead>
-          <tbody>
+      <div className="rounded-lg border">
+        <Table className="text-sm">
+          <TableHeader className="bg-neutral-50">
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>E-mail</TableHead>
+              <TableHead>Edycja</TableHead>
+              <TableHead>Rola</TableHead>
+              <TableHead>Aktywny</TableHead>
+              <TableHead>Akcje</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {users.map((u) => (
-              <tr key={u.id} className="border-t align-top">
-                <td className="px-3 py-2">{u.id}</td>
-                <td className="px-3 py-2">{u.email}</td>
-                <td className="px-3 py-2">{u.firstName ?? "—"}</td>
-                <td className="px-3 py-2">{u.role}</td>
-                <td className="px-3 py-2">{u.isActive ? "tak" : "nie"}</td>
+              <TableRow key={u.id} className="align-top">
+                <TableCell>{u.id}</TableCell>
+                <TableCell>{u.email}</TableCell>
+                <TableCell>{u.firstName ?? "—"}</TableCell>
+                <TableCell>{u.role}</TableCell>
+                <TableCell>{u.isActive ? "tak" : "nie"}</TableCell>
                 <UserRowActions id={u.id} firstName={u.firstName} role={u.role} isActive={u.isActive} />
-              </tr>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </div>
 
       <AddUserForm />
     </main>
-  );
+  )
 }

--- a/app/(panel)/panel-admin/zlecenia/AddOrderForm.tsx
+++ b/app/(panel)/panel-admin/zlecenia/AddOrderForm.tsx
@@ -1,116 +1,153 @@
-"use client";
+"use client"
 
-import { useState, useTransition } from "react";
-import { createOrderAction } from "./actions";
+import { useState, useTransition } from "react"
+import { createOrderAction } from "./actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
-type Monter = { id: number; firstName: string | null; email: string };
+type Monter = { id: number; firstName: string | null; email: string }
 
 export default function AddOrderForm({ monters }: { monters: Monter[] }) {
-  const [msg, setMsg] = useState<string | null>(null);
-  const [pending, start] = useTransition();
+  const [msg, setMsg] = useState<string | null>(null)
+  const [assignedTo, setAssignedTo] = useState<string>("")
+  const [pending, start] = useTransition()
 
   return (
     <form
       action={(fd) =>
         start(async () => {
-          setMsg(null);
-          const res = await createOrderAction(fd);
-          setMsg(res.error ?? (res.ok ? "Zlecenie dodane." : null));
+          setMsg(null)
+          fd.set("assignedToId", assignedTo)
+          const res = await createOrderAction(fd)
+          setMsg(res.error ?? (res.ok ? "Zlecenie dodane." : null))
         })
       }
-      className="space-y-4 max-w-xl rounded-lg border p-4"
+      className="max-w-xl space-y-4 rounded-lg border p-4"
     >
       <h2 className="text-lg font-medium">Dodaj zlecenie</h2>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Klient</label>
-        <input
+      <div className="grid gap-2">
+        <Label htmlFor="order-customer" className="text-sm">
+          Klient
+        </Label>
+        <Input
+          id="order-customer"
           name="customerName"
           required
-          className="w-full rounded-md border px-3 py-2"
           placeholder="Jan Kowalski"
         />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Miasto</label>
-        <input
+      <div className="grid gap-2">
+        <Label htmlFor="order-city" className="text-sm">
+          Miasto
+        </Label>
+        <Input
+          id="order-city"
           name="city"
           required
-          className="w-full rounded-md border px-3 py-2"
           placeholder="Warszawa"
         />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Telefon</label>
-        <input
+      <div className="grid gap-2">
+        <Label htmlFor="order-phone" className="text-sm">
+          Telefon
+        </Label>
+        <Input
+          id="order-phone"
           name="phone"
           required
-          className="w-full rounded-md border px-3 py-2"
           placeholder="600 000 000"
         />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Adres</label>
-        <input name="address" className="w-full rounded-md border px-3 py-2" />
+      <div className="grid gap-2">
+        <Label htmlFor="order-address" className="text-sm">
+          Adres
+        </Label>
+        <Input id="order-address" name="address" />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Wstępny metraż (m²)</label>
-        <input
+      <div className="grid gap-2">
+        <Label htmlFor="order-area" className="text-sm">
+          Wstępny metraż (m²)
+        </Label>
+        <Input
+          id="order-area"
           name="initialArea"
           type="number"
           min="0"
           step="0.01"
           required
-          className="w-full rounded-md border px-3 py-2"
           placeholder="45"
         />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Wybrany panel</label>
-        <input
+      <div className="grid gap-2">
+        <Label htmlFor="order-panel" className="text-sm">
+          Wybrany panel
+        </Label>
+        <Input
+          id="order-panel"
           name="selectedPanel"
-          className="w-full rounded-md border px-3 py-2"
           placeholder="Panel Dąb Naturalny"
         />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Notatka dla montera</label>
-        <textarea
+      <div className="grid gap-2">
+        <Label htmlFor="order-notes" className="text-sm">
+          Notatka dla montera
+        </Label>
+        <Textarea
+          id="order-notes"
           name="notes"
           rows={3}
-          className="w-full rounded-md border px-3 py-2"
           placeholder="Dodatkowe informacje od klienta"
         />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Planowana data</label>
-        <input name="plannedDate" type="date" className="w-full rounded-md border px-3 py-2" />
+      <div className="grid gap-2">
+        <Label htmlFor="order-date" className="text-sm">
+          Planowana data
+        </Label>
+        <Input id="order-date" name="plannedDate" type="date" />
       </div>
 
-      <div className="grid gap-1">
-        <label className="text-sm">Przypisz montera</label>
-        <select name="assignedToId" className="w-full rounded-md border px-3 py-2">
-          <option value="">— brak —</option>
-          {monters.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.firstName ?? m.email} ({m.email})
-            </option>
-          ))}
-        </select>
+      <div className="grid gap-2">
+        <Label htmlFor="order-assigned" className="text-sm">
+          Przypisz montera
+        </Label>
+        <Select value={assignedTo} onValueChange={setAssignedTo}>
+          <SelectTrigger id="order-assigned">
+            <SelectValue placeholder="— brak —" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">— brak —</SelectItem>
+            {monters.map((m) => (
+              <SelectItem key={m.id} value={String(m.id)}>
+                {m.firstName ?? m.email} ({m.email})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <input type="hidden" name="assignedToId" value={assignedTo} />
       </div>
 
-      <button disabled={pending} className="rounded-md border px-4 py-2 font-medium hover:bg-neutral-50 disabled:opacity-60">
+      <Button disabled={pending} className="font-medium">
         {pending ? "Dodaję..." : "Dodaj zlecenie"}
-      </button>
+      </Button>
 
-      {msg && <p className="text-sm text-red-600">{msg}</p>}
+      {msg && <p className="text-sm text-destructive">{msg}</p>}
     </form>
-  );
+  )
 }

--- a/app/(panel)/panel-admin/zlecenia/OrderRowActions.tsx
+++ b/app/(panel)/panel-admin/zlecenia/OrderRowActions.tsx
@@ -1,10 +1,21 @@
-"use client";
+"use client"
 
-import { useState, useTransition } from "react";
-import { assignOrderAction, updateOrderAction, deleteOrderAction } from "./actions";
-import type { OrderStatus } from "@prisma/client";
+import { useState, useTransition } from "react"
+import { assignOrderAction, updateOrderAction, deleteOrderAction } from "./actions"
+import type { OrderStatus } from "@prisma/client"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
-type Monter = { id: number; firstName: string | null; email: string };
+type Monter = { id: number; firstName: string | null; email: string }
 
 export default function OrderRowActions(props: {
   id: number;
@@ -20,59 +31,80 @@ export default function OrderRowActions(props: {
   selectedPanel: string;
   notes: string;
 }) {
-  const [msg, setMsg] = useState<string | null>(null);
-  const [detailsMsg, setDetailsMsg] = useState<string | null>(null);
-  const [pending, start] = useTransition();
+  const [msg, setMsg] = useState<string | null>(null)
+  const [detailsMsg, setDetailsMsg] = useState<string | null>(null)
+  const [status, setStatus] = useState<OrderStatus>(props.status)
+  const [assigned, setAssigned] = useState<string>(props.assignedToId ? String(props.assignedToId) : "")
+  const [pending, start] = useTransition()
 
   return (
-    <td className="px-3 py-2 space-y-4">
+    <td className="space-y-4 px-3 py-2">
       {/* Status + data */}
       <form
-        className="flex items-center gap-2"
+        className="flex flex-wrap items-center gap-2"
         action={(fd) =>
           start(async () => {
-            setMsg(null);
-            fd.set("id", String(props.id));
-            const res = await updateOrderAction(fd);
-            setMsg(res.error ?? (res.ok ? "Zapisano." : null));
+            setMsg(null)
+            fd.set("id", String(props.id))
+            fd.set("status", status)
+            const res = await updateOrderAction(fd)
+            setMsg(res.error ?? (res.ok ? "Zapisano." : null))
           })
         }
       >
-        <select name="status" defaultValue={props.status} className="rounded-md border px-2 py-1">
-          <option value="NOWE">NOWE</option>
-          <option value="W_TRAKCIE">W TRAKCIE</option>
-          <option value="ZAKONCZONE">ZAKOŃCZONE</option>
-          <option value="ANULOWANE">ANULOWANE</option>
-        </select>
-        <input name="plannedDate" type="date" defaultValue={props.plannedDate ?? undefined} className="rounded-md border px-2 py-1" />
-        <button disabled={pending} className="rounded-md border px-2 py-1 disabled:opacity-60 hover:bg-neutral-50">
+        <Select value={status} onValueChange={(value) => setStatus(value as OrderStatus)}>
+          <SelectTrigger className="h-9 w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="NOWE">NOWE</SelectItem>
+            <SelectItem value="W_TRAKCIE">W TRAKCIE</SelectItem>
+            <SelectItem value="ZAKONCZONE">ZAKOŃCZONE</SelectItem>
+            <SelectItem value="ANULOWANE">ANULOWANE</SelectItem>
+          </SelectContent>
+        </Select>
+        <input type="hidden" name="status" value={status} />
+        <Input
+          name="plannedDate"
+          type="date"
+          defaultValue={props.plannedDate ?? undefined}
+          className="h-9 w-40"
+        />
+        <Button variant="outline" size="sm" disabled={pending}>
           Zapisz
-        </button>
+        </Button>
       </form>
 
       {/* Przypisz montera */}
       <form
-        className="flex items-center gap-2"
+        className="flex flex-wrap items-center gap-2"
         action={(fd) =>
           start(async () => {
-            setMsg(null);
-            fd.set("id", String(props.id));
-            const res = await assignOrderAction(fd);
-            setMsg(res.error ?? (res.ok ? "Zapisano." : null));
+            setMsg(null)
+            fd.set("id", String(props.id))
+            fd.set("assignedToId", assigned)
+            const res = await assignOrderAction(fd)
+            setMsg(res.error ?? (res.ok ? "Zapisano." : null))
           })
         }
       >
-        <select name="assignedToId" defaultValue={props.assignedToId ?? ""} className="rounded-md border px-2 py-1">
-          <option value="">— brak —</option>
-          {props.monters.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.firstName ?? m.email} ({m.email})
-            </option>
-          ))}
-        </select>
-        <button disabled={pending} className="rounded-md border px-2 py-1 disabled:opacity-60 hover:bg-neutral-50">
+        <Select value={assigned} onValueChange={setAssigned}>
+          <SelectTrigger className="h-9 w-48">
+            <SelectValue placeholder="— brak —" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">— brak —</SelectItem>
+            {props.monters.map((m) => (
+              <SelectItem key={m.id} value={String(m.id)}>
+                {m.firstName ?? m.email} ({m.email})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <input type="hidden" name="assignedToId" value={assigned} />
+        <Button variant="outline" size="sm" disabled={pending}>
           Przypisz
-        </button>
+        </Button>
       </form>
 
       {/* Szczegóły */}
@@ -80,81 +112,128 @@ export default function OrderRowActions(props: {
         className="grid gap-2"
         action={(fd) =>
           start(async () => {
-            setDetailsMsg(null);
-            fd.set("id", String(props.id));
-            const res = await updateOrderAction(fd);
-            setDetailsMsg(res.error ?? (res.ok ? "Zapisano." : null));
+            setDetailsMsg(null)
+            fd.set("id", String(props.id))
+            const res = await updateOrderAction(fd)
+            setDetailsMsg(res.error ?? (res.ok ? "Zapisano." : null))
           })
         }
       >
         <div className="grid gap-1">
-          <label className="text-xs uppercase tracking-wide text-neutral-500">Klient</label>
-          <input
+          <Label
+            htmlFor={`order-customer-${props.id}`}
+            className="text-xs uppercase tracking-wide text-neutral-500"
+          >
+            Klient
+          </Label>
+          <Input
+            id={`order-customer-${props.id}`}
             name="customerName"
             defaultValue={props.customerName}
-            className="rounded-md border px-2 py-1"
+            className="h-9"
           />
         </div>
         <div className="grid gap-1">
-          <label className="text-xs uppercase tracking-wide text-neutral-500">Miasto</label>
-          <input name="city" defaultValue={props.city} className="rounded-md border px-2 py-1" />
+          <Label
+            htmlFor={`order-city-${props.id}`}
+            className="text-xs uppercase tracking-wide text-neutral-500"
+          >
+            Miasto
+          </Label>
+          <Input id={`order-city-${props.id}`} name="city" defaultValue={props.city} className="h-9" />
         </div>
         <div className="grid gap-1">
-          <label className="text-xs uppercase tracking-wide text-neutral-500">Telefon</label>
-          <input name="phone" defaultValue={props.phone} className="rounded-md border px-2 py-1" />
+          <Label
+            htmlFor={`order-phone-${props.id}`}
+            className="text-xs uppercase tracking-wide text-neutral-500"
+          >
+            Telefon
+          </Label>
+          <Input id={`order-phone-${props.id}`} name="phone" defaultValue={props.phone} className="h-9" />
         </div>
         <div className="grid gap-1">
-          <label className="text-xs uppercase tracking-wide text-neutral-500">Adres</label>
-          <input name="address" defaultValue={props.address} className="rounded-md border px-2 py-1" />
+          <Label
+            htmlFor={`order-address-${props.id}`}
+            className="text-xs uppercase tracking-wide text-neutral-500"
+          >
+            Adres
+          </Label>
+          <Input id={`order-address-${props.id}`} name="address" defaultValue={props.address} className="h-9" />
         </div>
         <div className="grid gap-1">
-          <label className="text-xs uppercase tracking-wide text-neutral-500">Wstępny metraż (m²)</label>
-          <input
+          <Label
+            htmlFor={`order-area-${props.id}`}
+            className="text-xs uppercase tracking-wide text-neutral-500"
+          >
+            Wstępny metraż (m²)
+          </Label>
+          <Input
+            id={`order-area-${props.id}`}
             name="initialArea"
             type="number"
             step="0.01"
             min="0"
             defaultValue={props.initialArea ?? ""}
-            className="rounded-md border px-2 py-1"
+            className="h-9"
           />
         </div>
         <div className="grid gap-1">
-          <label className="text-xs uppercase tracking-wide text-neutral-500">Panel</label>
-          <input name="selectedPanel" defaultValue={props.selectedPanel} className="rounded-md border px-2 py-1" />
+          <Label
+            htmlFor={`order-panel-${props.id}`}
+            className="text-xs uppercase tracking-wide text-neutral-500"
+          >
+            Panel
+          </Label>
+          <Input
+            id={`order-panel-${props.id}`}
+            name="selectedPanel"
+            defaultValue={props.selectedPanel}
+            className="h-9"
+          />
         </div>
         <div className="grid gap-1">
-          <label className="text-xs uppercase tracking-wide text-neutral-500">Notatka</label>
-          <textarea
+          <Label
+            htmlFor={`order-notes-${props.id}`}
+            className="text-xs uppercase tracking-wide text-neutral-500"
+          >
+            Notatka
+          </Label>
+          <Textarea
+            id={`order-notes-${props.id}`}
             name="notes"
             rows={2}
             defaultValue={props.notes}
-            className="rounded-md border px-2 py-1"
           />
         </div>
-        <button disabled={pending} className="rounded-md border px-2 py-1 disabled:opacity-60 hover:bg-neutral-50">
+        <Button variant="outline" size="sm" disabled={pending}>
           Zapisz dane
-        </button>
+        </Button>
       </form>
 
       {/* Usuń */}
       <form
         action={() =>
           start(async () => {
-            setMsg(null);
-            const fd = new FormData();
-            fd.set("id", String(props.id));
-            const res = await deleteOrderAction(fd);
-            setMsg(res.error ?? (res.ok ? "Usunięto." : null));
+            setMsg(null)
+            const fd = new FormData()
+            fd.set("id", String(props.id))
+            const res = await deleteOrderAction(fd)
+            setMsg(res.error ?? (res.ok ? "Usunięto." : null))
           })
         }
       >
-        <button disabled={pending} className="rounded-md border px-2 py-1 text-red-600 hover:bg-red-50 disabled:opacity-60">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={pending}
+          className="text-destructive hover:bg-destructive/10"
+        >
           Usuń
-        </button>
+        </Button>
       </form>
 
-      {msg && <p className="text-xs text-red-600">{msg}</p>}
-      {detailsMsg && <p className="text-xs text-red-600">{detailsMsg}</p>}
+      {msg && <p className="text-xs text-destructive">{msg}</p>}
+      {detailsMsg && <p className="text-xs text-destructive">{detailsMsg}</p>}
     </td>
-  );
+  )
 }

--- a/app/(panel)/panel-admin/zlecenia/page.tsx
+++ b/app/(panel)/panel-admin/zlecenia/page.tsx
@@ -1,16 +1,24 @@
-import { getSession } from "@/lib/session";
-import { redirect } from "next/navigation";
-import prisma from "@/lib/prisma";
-import { Role } from "@prisma/client";
-import { formatArea } from "@/lib/orderTitle";
-import AddOrderForm from "./AddOrderForm";
-import OrderRowActions from "./OrderRowActions";
+import { getSession } from "@/lib/session"
+import { redirect } from "next/navigation"
+import prisma from "@/lib/prisma"
+import { Role } from "@prisma/client"
+import { formatArea } from "@/lib/orderTitle"
+import AddOrderForm from "./AddOrderForm"
+import OrderRowActions from "./OrderRowActions"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 
 export const metadata = { title: "Zlecenia — Admin" };
 
 export default async function OrdersPage() {
-  const s = await getSession();
-  if (!s || s.user.role !== Role.ADMIN) redirect("/");
+  const s = await getSession()
+  if (!s || s.user.role !== Role.ADMIN) redirect("/")
 
   const [orders, monters] = await Promise.all([
     prisma.order.findMany({
@@ -51,43 +59,43 @@ export default async function OrdersPage() {
       select: { id: true, firstName: true, email: true },
       orderBy: [{ firstName: "asc" }, { email: "asc" }],
     }),
-  ]);
+  ])
 
-  const toDateInput = (d: Date | null) => (d ? new Date(d).toISOString().slice(0, 10) : null);
+  const toDateInput = (d: Date | null) => (d ? new Date(d).toISOString().slice(0, 10) : null)
 
   return (
-    <main className="p-8 space-y-8">
+    <main className="space-y-8 p-8">
       <h1 className="text-2xl font-semibold">Zlecenia</h1>
 
-      <div className="overflow-x-auto rounded-lg border">
-        <table className="w-full text-sm">
-          <thead className="bg-neutral-50">
-            <tr>
-              <th className="px-3 py-2 text-left">ID</th>
-              <th className="px-3 py-2 text-left">Tytuł</th>
-              <th className="px-3 py-2 text-left">Klient / Kontakt</th>
-              <th className="px-3 py-2 text-left">Panele &amp; pomiar</th>
-              <th className="px-3 py-2 text-left">Monter</th>
-              <th className="px-3 py-2 text-left">Edycja</th>
-            </tr>
-          </thead>
-          <tbody>
+      <div className="rounded-lg border">
+        <Table className="text-sm">
+          <TableHeader className="bg-neutral-50">
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Tytuł</TableHead>
+              <TableHead>Klient / Kontakt</TableHead>
+              <TableHead>Panele &amp; pomiar</TableHead>
+              <TableHead>Monter</TableHead>
+              <TableHead>Edycja</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {orders.map((o) => {
               const diff =
                 o.measuredArea !== null && o.initialArea !== null
                   ? o.measuredArea - o.initialArea
-                  : null;
+                  : null
 
               return (
-                <tr key={o.id} className="border-t align-top">
-                  <td className="px-3 py-2">{o.id}</td>
-                  <td className="px-3 py-2">
+                <TableRow key={o.id} className="align-top">
+                  <TableCell>{o.id}</TableCell>
+                  <TableCell>
                     <div className="font-medium">{o.title}</div>
                     <div className="text-xs text-neutral-500">
                       {o.status} · plan: {toDateInput(o.plannedDate) ?? "—"}
                     </div>
-                  </td>
-                  <td className="px-3 py-2 space-y-1">
+                  </TableCell>
+                  <TableCell className="space-y-1">
                     <div className="font-medium">{o.customerName ?? "—"}</div>
                     <div className="text-xs text-neutral-500">{o.city ?? "—"}</div>
                     <div className="text-xs text-neutral-500">tel. {o.phone ?? "—"}</div>
@@ -95,8 +103,8 @@ export default async function OrdersPage() {
                     {o.notes && (
                       <div className="text-xs text-neutral-500">Notatka: {o.notes}</div>
                     )}
-                  </td>
-                  <td className="px-3 py-2 space-y-1">
+                  </TableCell>
+                  <TableCell className="space-y-1">
                     <div>{o.selectedPanel ?? "—"}</div>
                     <div className="text-xs text-neutral-500">
                       Wstępnie: {formatArea(o.initialArea) ?? "—"} m²
@@ -128,10 +136,10 @@ export default async function OrdersPage() {
                         {o.measurement.carryNote && <div>Wnoszenie: {o.measurement.carryNote}</div>}
                       </div>
                     )}
-                  </td>
-                  <td className="px-3 py-2">
+                  </TableCell>
+                  <TableCell>
                     {o.assignedTo ? (o.assignedTo.firstName ?? o.assignedTo.email) : "—"}
-                  </td>
+                  </TableCell>
                   <OrderRowActions
                     id={o.id}
                     status={o.status}
@@ -146,14 +154,14 @@ export default async function OrdersPage() {
                     selectedPanel={o.selectedPanel ?? ""}
                     notes={o.notes ?? ""}
                   />
-                </tr>
-              );
+                </TableRow>
+              )
             })}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </div>
 
       <AddOrderForm monters={monters} />
     </main>
-  );
+  )
 }

--- a/app/(panel)/panel-montazysty/zlecenia/[id]/MeasurementForm.tsx
+++ b/app/(panel)/panel-montazysty/zlecenia/[id]/MeasurementForm.tsx
@@ -1,8 +1,19 @@
-"use client";
+"use client"
 
-import { useState, useTransition } from "react";
-import { TrimMode } from "@prisma/client";
-import { saveMeasurementAction } from "../actions";
+import { useState, useTransition } from "react"
+import { TrimMode } from "@prisma/client"
+import { saveMeasurementAction } from "../actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
 type Props = {
   orderId: number;
@@ -21,31 +32,32 @@ type Props = {
     deliveryOffsetDays: number | null;
     carryNote: string | null;
   } | null;
-};
+}
 
 export default function MeasurementForm(props: Props) {
-  const [message, setMessage] = useState<string | null>(null);
-  const [pending, startTransition] = useTransition();
-  const [mode, setMode] = useState<TrimMode>(props.measurement?.trimMode ?? TrimMode.WITH_PANELS);
+  const [message, setMessage] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+  const [mode, setMode] = useState<TrimMode>(props.measurement?.trimMode ?? TrimMode.WITH_PANELS)
 
-  const installationAddress = props.measurement?.installationAddress ?? props.orderAddress ?? "";
-  const panelName = props.measurement?.panelName ?? props.selectedPanel ?? "";
-  const measuredAreaDefault = props.measurement?.measuredArea ?? "";
-  const wastePercentageDefault = props.measurement?.wastePercentage?.toString() ?? "10";
-  const installationDateDefault = props.measurement?.installationDate ?? null;
-  const deliveryDateDefault = props.measurement?.deliveryDate ?? null;
-  const deliveryOffsetDefault = props.measurement?.deliveryOffsetDays?.toString() ?? "";
-  const carryNoteDefault = props.measurement?.carryNote ?? "";
+  const installationAddress = props.measurement?.installationAddress ?? props.orderAddress ?? ""
+  const panelName = props.measurement?.panelName ?? props.selectedPanel ?? ""
+  const measuredAreaDefault = props.measurement?.measuredArea ?? ""
+  const wastePercentageDefault = props.measurement?.wastePercentage?.toString() ?? "10"
+  const installationDateDefault = props.measurement?.installationDate ?? null
+  const deliveryDateDefault = props.measurement?.deliveryDate ?? null
+  const deliveryOffsetDefault = props.measurement?.deliveryOffsetDays?.toString() ?? ""
+  const carryNoteDefault = props.measurement?.carryNote ?? ""
 
   return (
     <form
       className="space-y-4 rounded-lg border p-4"
       action={(fd) =>
         startTransition(async () => {
-          setMessage(null);
-          fd.set("orderId", String(props.orderId));
-          const res = await saveMeasurementAction(fd);
-          setMessage(res.error ?? (res.ok ? "Pomiar zapisany." : null));
+          setMessage(null)
+          fd.set("orderId", String(props.orderId))
+          fd.set("trimMode", mode)
+          const res = await saveMeasurementAction(fd)
+          setMessage(res.error ?? (res.ok ? "Pomiar zapisany." : null))
         })
       }
     >
@@ -58,41 +70,52 @@ export default function MeasurementForm(props: Props) {
 
       <div className="grid gap-2 sm:grid-cols-2">
         <div className="grid gap-1 sm:col-span-2">
-          <label className="text-sm">Adres montażu</label>
-          <textarea
+          <Label htmlFor="installation-address" className="text-sm">
+            Adres montażu
+          </Label>
+          <Textarea
+            id="installation-address"
             name="installationAddress"
             required
             defaultValue={installationAddress}
             rows={2}
-            className="w-full rounded-md border px-3 py-2"
           />
         </div>
         <div className="grid gap-1">
-          <label className="text-sm">Listwy</label>
-          <select
-            name="trimMode"
-            value={mode}
-            onChange={(e) => setMode(e.target.value as TrimMode)}
-            className="w-full rounded-md border px-3 py-2"
-          >
-            <option value={TrimMode.WITH_PANELS}>Razem z panelami</option>
-            <option value={TrimMode.SEPARATE}>Osobno</option>
-          </select>
+          <Label htmlFor="trim-mode" className="text-sm">
+            Listwy
+          </Label>
+          <Select value={mode} onValueChange={(value) => setMode(value as TrimMode)}>
+            <SelectTrigger id="trim-mode">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={TrimMode.WITH_PANELS}>Razem z panelami</SelectItem>
+              <SelectItem value={TrimMode.SEPARATE}>Osobno</SelectItem>
+            </SelectContent>
+          </Select>
+          <input type="hidden" name="trimMode" value={mode} />
         </div>
         <div className="grid gap-1">
-          <label className="text-sm">Wstępny metraż</label>
-          <input
+          <Label className="text-sm" htmlFor="initial-area-readonly">
+            Wstępny metraż
+          </Label>
+          <Input
+            id="initial-area-readonly"
             value={props.initialArea}
             readOnly
-            className="w-full rounded-md border bg-neutral-100 px-3 py-2 text-neutral-500"
+            className="bg-neutral-100 text-neutral-500"
           />
         </div>
         <div className="grid gap-1">
-          <label className="text-sm">Ostatni pomiar</label>
-          <input
+          <Label className="text-sm" htmlFor="measured-area-readonly">
+            Ostatni pomiar
+          </Label>
+          <Input
+            id="measured-area-readonly"
             value={props.measuredArea}
             readOnly
-            className="w-full rounded-md border bg-neutral-100 px-3 py-2 text-neutral-500"
+            className="bg-neutral-100 text-neutral-500"
           />
         </div>
       </div>
@@ -104,37 +127,43 @@ export default function MeasurementForm(props: Props) {
         </p>
 
         <div className="grid gap-1">
-          <label className="text-sm">Panel</label>
-          <input
+          <Label htmlFor="panel-name" className="text-sm">
+            Panel
+          </Label>
+          <Input
+            id="panel-name"
             name="panelName"
             defaultValue={panelName}
             placeholder="Panel Dąb Naturalny"
-            className="w-full rounded-md border px-3 py-2"
           />
         </div>
 
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="grid gap-1">
-            <label className="text-sm">Pomiar (m²)</label>
-            <input
+            <Label htmlFor="measured-area" className="text-sm">
+              Pomiar (m²)
+            </Label>
+            <Input
+              id="measured-area"
               name="measuredArea"
               type="number"
               min="0"
               step="0.01"
               defaultValue={measuredAreaDefault}
-              className="w-full rounded-md border px-3 py-2"
               required
             />
           </div>
           <div className="grid gap-1">
-            <label className="text-sm">Zapas na docinki (%)</label>
-            <input
+            <Label htmlFor="waste-percentage" className="text-sm">
+              Zapas na docinki (%)
+            </Label>
+            <Input
+              id="waste-percentage"
               name="wastePercentage"
               type="number"
               min="5"
               max="20"
               defaultValue={wastePercentageDefault}
-              className="w-full rounded-md border px-3 py-2"
               required
             />
           </div>
@@ -142,67 +171,67 @@ export default function MeasurementForm(props: Props) {
 
         <div className="grid gap-3 sm:grid-cols-3">
           <div className="grid gap-1">
-            <label className="text-sm">Termin montażu</label>
-            <input
+            <Label htmlFor="installation-date" className="text-sm">
+              Termin montażu
+            </Label>
+            <Input
+              id="installation-date"
               name="installationDate"
               type="date"
               defaultValue={installationDateDefault ?? undefined}
-              className="w-full rounded-md border px-3 py-2"
             />
           </div>
           <div className="grid gap-1">
-            <label className="text-sm">Termin dostawy paneli</label>
-            <input
+            <Label htmlFor="delivery-date" className="text-sm">
+              Termin dostawy paneli
+            </Label>
+            <Input
+              id="delivery-date"
               name="deliveryDate"
               type="date"
               defaultValue={deliveryDateDefault ?? undefined}
-              className="w-full rounded-md border px-3 py-2"
             />
           </div>
           <div className="grid gap-1">
-            <label className="text-sm">Ile dni wcześniej?</label>
-            <input
+            <Label htmlFor="delivery-offset" className="text-sm">
+              Ile dni wcześniej?
+            </Label>
+            <Input
+              id="delivery-offset"
               name="deliveryOffsetDays"
               type="number"
               min="0"
               defaultValue={deliveryOffsetDefault}
-              className="w-full rounded-md border px-3 py-2"
             />
           </div>
         </div>
 
         <div className="grid gap-1">
-          <label className="text-sm">Wnoszenie</label>
-          <textarea
+          <Label htmlFor="carry-note" className="text-sm">
+            Wnoszenie
+          </Label>
+          <Textarea
+            id="carry-note"
             name="carryNote"
             rows={2}
             placeholder="Np. 4 piętro bez windy"
             defaultValue={carryNoteDefault}
-            className="w-full rounded-md border px-3 py-2"
           />
         </div>
 
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <button
-            type="submit"
-            disabled={pending}
-            className="inline-flex items-center rounded-md border px-4 py-2 font-medium hover:bg-neutral-50 disabled:opacity-60"
-          >
+          <Button type="submit" disabled={pending} className="font-medium">
             {pending ? "Zapisuję..." : "Zapisz pomiar"}
-          </button>
+          </Button>
           {mode === TrimMode.SEPARATE && (
-            <button
-              type="button"
-              disabled
-              className="inline-flex items-center rounded-md border border-dashed px-4 py-2 text-neutral-400"
-            >
+            <Button type="button" variant="outline" disabled className="border-dashed text-neutral-400">
               Pomiar listwy (w przygotowaniu)
-            </button>
+            </Button>
           )}
         </div>
       </fieldset>
 
-      {message && <p className="text-sm text-red-600">{message}</p>}
+      {message && <p className="text-sm text-destructive">{message}</p>}
     </form>
-  );
+  )
 }

--- a/app/(panel)/panel-montazysty/zlecenia/[id]/StatusForm.tsx
+++ b/app/(panel)/panel-montazysty/zlecenia/[id]/StatusForm.tsx
@@ -1,8 +1,18 @@
-"use client";
+"use client"
 
-import { useState, useTransition } from "react";
-import type { OrderStatus } from "@prisma/client";
-import { updateMyOrderAction } from "../actions";
+import { useState, useTransition } from "react"
+import type { OrderStatus } from "@prisma/client"
+import { updateMyOrderAction } from "../actions"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
 type Props = {
   orderId: number;
@@ -11,18 +21,20 @@ type Props = {
 };
 
 export default function StatusForm({ orderId, status, notes }: Props) {
-  const [message, setMessage] = useState<string | null>(null);
-  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null)
+  const [statusValue, setStatusValue] = useState<OrderStatus>(status)
+  const [pending, startTransition] = useTransition()
 
   return (
     <form
       className="space-y-3 rounded-lg border p-4"
       action={(fd) =>
         startTransition(async () => {
-          setMessage(null);
-          fd.set("id", String(orderId));
-          const res = await updateMyOrderAction(fd);
-          setMessage(res.error ?? (res.ok ? "Zapisano status." : null));
+          setMessage(null)
+          fd.set("id", String(orderId))
+          fd.set("status", statusValue)
+          const res = await updateMyOrderAction(fd)
+          setMessage(res.error ?? (res.ok ? "Zapisano status." : null))
         })
       }
     >
@@ -34,34 +46,41 @@ export default function StatusForm({ orderId, status, notes }: Props) {
       </div>
 
       <div className="grid gap-1 sm:max-w-xs">
-        <label className="text-sm">Status</label>
-        <select name="status" defaultValue={status} className="rounded-md border px-2 py-1">
-          <option value="NOWE">NOWE</option>
-          <option value="W_TRAKCIE">W TRAKCIE</option>
-          <option value="ZAKONCZONE">ZAKOŃCZONE</option>
-          <option value="ANULOWANE">ANULOWANE</option>
-        </select>
+        <Label htmlFor="order-status" className="text-sm">
+          Status
+        </Label>
+        <Select value={statusValue} onValueChange={(value) => setStatusValue(value as OrderStatus)}>
+          <SelectTrigger id="order-status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="NOWE">NOWE</SelectItem>
+            <SelectItem value="W_TRAKCIE">W TRAKCIE</SelectItem>
+            <SelectItem value="ZAKONCZONE">ZAKOŃCZONE</SelectItem>
+            <SelectItem value="ANULOWANE">ANULOWANE</SelectItem>
+          </SelectContent>
+        </Select>
+        <input type="hidden" name="status" value={statusValue} />
       </div>
 
       <div className="grid gap-1">
-        <label className="text-sm">Notatka</label>
-        <textarea
+        <Label htmlFor="order-note" className="text-sm">
+          Notatka
+        </Label>
+        <Textarea
+          id="order-note"
           name="notes"
           rows={3}
           defaultValue={notes ?? ""}
           placeholder="Wpisz dodatkowe informacje..."
-          className="w-full rounded-md border px-3 py-2"
         />
       </div>
 
-      <button
-        disabled={pending}
-        className="rounded-md border px-4 py-2 font-medium hover:bg-neutral-50 disabled:opacity-60"
-      >
+      <Button disabled={pending} className="font-medium">
         {pending ? "Zapisuję..." : "Zapisz"}
-      </button>
+      </Button>
 
-      {message && <p className="text-sm text-red-600">{message}</p>}
+      {message && <p className="text-sm text-destructive">{message}</p>}
     </form>
-  );
+  )
 }

--- a/app/(panel)/panel-montazysty/zlecenia/page.tsx
+++ b/app/(panel)/panel-montazysty/zlecenia/page.tsx
@@ -1,15 +1,24 @@
-import { getSession } from "@/lib/session";
-import { redirect } from "next/navigation";
-import prisma from "@/lib/prisma";
-import { Role } from "@prisma/client";
-import Link from "next/link";
-import { formatArea } from "@/lib/orderTitle";
+import { getSession } from "@/lib/session"
+import { redirect } from "next/navigation"
+import prisma from "@/lib/prisma"
+import { Role } from "@prisma/client"
+import Link from "next/link"
+import { formatArea } from "@/lib/orderTitle"
+import { Button } from "@/components/ui/button"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 
 export const metadata = { title: "Moje zlecenia — Monter" };
 
 export default async function MyOrdersPage() {
-  const s = await getSession();
-  if (!s || s.user.role !== Role.MONTAZYSTA) redirect("/");
+  const s = await getSession()
+  if (!s || s.user.role !== Role.MONTAZYSTA) redirect("/")
 
   const orders = await prisma.order.findMany({
     where: { assignedToId: s.user.id },
@@ -28,35 +37,35 @@ export default async function MyOrdersPage() {
       measuredArea: true,
       selectedPanel: true,
     },
-  });
+  })
 
-  const toDate = (d: Date | null) => (d ? new Date(d).toISOString().slice(0, 10) : "—");
+  const toDate = (d: Date | null) => (d ? new Date(d).toISOString().slice(0, 10) : "—")
 
   return (
-    <main className="p-8 space-y-8">
+    <main className="space-y-8 p-8">
       <h1 className="text-2xl font-semibold">Moje zlecenia</h1>
 
-      <div className="overflow-x-auto rounded-lg border">
-        <table className="w-full text-sm">
-          <thead className="bg-neutral-50">
-            <tr>
-              <th className="px-3 py-2 text-left">ID</th>
-              <th className="px-3 py-2 text-left">Tytuł</th>
-              <th className="px-3 py-2 text-left">Klient / Adres</th>
-              <th className="px-3 py-2 text-left">Plan</th>
-              <th className="px-3 py-2 text-left">Panele</th>
-              <th className="px-3 py-2 text-left">Akcje</th>
-            </tr>
-          </thead>
-          <tbody>
+      <div className="rounded-lg border">
+        <Table className="text-sm">
+          <TableHeader className="bg-neutral-50">
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Tytuł</TableHead>
+              <TableHead>Klient / Adres</TableHead>
+              <TableHead>Plan</TableHead>
+              <TableHead>Panele</TableHead>
+              <TableHead>Akcje</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {orders.map((o) => (
-              <tr key={o.id} className="border-t align-top">
-                <td className="px-3 py-2">{o.id}</td>
-                <td className="px-3 py-2">
+              <TableRow key={o.id} className="align-top">
+                <TableCell>{o.id}</TableCell>
+                <TableCell>
                   <div className="font-medium">{o.title}</div>
                   <div className="text-xs text-neutral-500">Status: {o.status}</div>
-                </td>
-                <td className="px-3 py-2">
+                </TableCell>
+                <TableCell>
                   <div>{o.customerName ?? "—"}</div>
                   <div className="text-xs text-neutral-500">{o.address ?? "—"}</div>
                   <div className="text-xs text-neutral-500">{o.city ?? "—"}</div>
@@ -64,33 +73,30 @@ export default async function MyOrdersPage() {
                   {o.notes && (
                     <div className="text-xs text-neutral-500">Notatka: {o.notes}</div>
                   )}
-                </td>
-                <td className="px-3 py-2">{toDate(o.plannedDate)}</td>
-                <td className="px-3 py-2 text-xs text-neutral-500">
+                </TableCell>
+                <TableCell>{toDate(o.plannedDate)}</TableCell>
+                <TableCell className="text-xs text-neutral-500">
                   <div className="text-sm text-neutral-700">{o.selectedPanel ?? "—"}</div>
                   <div>Wstępnie: {formatArea(o.initialArea) ?? "—"} m²</div>
                   <div>Pomiar: {formatArea(o.measuredArea) ?? "—"} m²</div>
-                </td>
-                <td className="px-3 py-2">
-                  <Link
-                    href={`/panel-montazysty/zlecenia/${o.id}`}
-                    className="inline-flex items-center rounded-md border px-3 py-1 text-sm font-medium hover:bg-neutral-50"
-                  >
-                    Szczegóły
-                  </Link>
-                </td>
-              </tr>
+                </TableCell>
+                <TableCell>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/panel-montazysty/zlecenia/${o.id}`}>Szczegóły</Link>
+                  </Button>
+                </TableCell>
+              </TableRow>
             ))}
             {orders.length === 0 && (
-              <tr>
-                <td colSpan={6} className="px-3 py-6 text-center text-neutral-500">
+              <TableRow>
+                <TableCell colSpan={6} className="px-3 py-6 text-center text-neutral-500">
                   Brak przypisanych zleceń.
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             )}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </div>
     </main>
-  );
+  )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,10 @@
-// app/layout.tsx
-import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import type { Metadata, Viewport } from "next"
+import { Geist, Geist_Mono } from "next/font/google"
+import "./globals.css"
+import { Toaster } from "@/components/ui/sonner"
 
-const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
-const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
+const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] })
+const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] })
 
 export const metadata: Metadata = {
   title: {
@@ -27,34 +27,18 @@ export const metadata: Metadata = {
   icons: {
     icon: "/favicon.ico",
   },
-};
+}
 
 export const viewport: Viewport = {
   themeColor: [{ media: "(prefers-color-scheme: light)", color: "#ffffff" }],
   width: "device-width",
   initialScale: 1,
-};
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="pl">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-dvh`}>
-        {children}
-      </body>
-    </html>
-  );
 }
-// app/layout.tsx
-import type { Metadata } from "next"
-import "./globals.css"
-import { Toaster } from "@/components/ui/sonner"
-
-export const metadata: Metadata = { title: "App" }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pl">
-      <body>
+      <body className={`${geistSans.variable} ${geistMono.variable} min-h-dvh antialiased`}>
         {children}
         <Toaster richColors position="top-right" />
       </body>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,70 +1,76 @@
 "use client";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 
 export default function LoginPage() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-  const router = useRouter();
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const router = useRouter()
 
   async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setErr(null);
-    setLoading(true);
+    e.preventDefault()
+    setErr(null)
+    setLoading(true)
     try {
       const res = await fetch("/api/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),
-      });
-      const data = await res.json();
+      })
+      const data = await res.json()
       if (!res.ok || !data?.ok) {
-        setErr(data?.error || "Błędny email lub hasło");
-        return;
+        setErr(data?.error || "Błędny email lub hasło")
+        return
       }
       // na razie bez sesji – po prostu przenieś na dashboard
-      router.push("/dashboard");
+      router.push("/dashboard")
     } catch {
-      setErr("Błąd połączenia");
+      setErr("Błąd połączenia")
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
   }
 
   return (
-    <main style={{ maxWidth: 420, margin: "48px auto", fontFamily: "system-ui, sans-serif" }}>
-      <h1 style={{ fontSize: 24, marginBottom: 16 }}>Logowanie</h1>
-      <form onSubmit={onSubmit}>
-        <label style={{ display: "block", marginBottom: 12 }}>
-          Email
-          <input
+    <main className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center gap-6 px-4">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-semibold">Logowanie</h1>
+        <p className="text-sm text-muted-foreground">Uzyskaj dostęp do panelu administracyjnego.</p>
+      </div>
+      <form onSubmit={onSubmit} className="space-y-4 rounded-lg border p-6 shadow-sm">
+        <div className="space-y-2">
+          <Label htmlFor="login-email">Email</Label>
+          <Input
+            id="login-email"
             type="email"
-            style={{ width: "100%", padding: 8, marginTop: 6 }}
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="np. jan.kowalski@example.com"
             required
             autoFocus
           />
-        </label>
-        <label style={{ display: "block", marginBottom: 12 }}>
-          Hasło
-          <input
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="login-password">Hasło</Label>
+          <Input
+            id="login-password"
             type="password"
-            style={{ width: "100%", padding: 8, marginTop: 6 }}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Wpisz swoje hasło"
             required
           />
-        </label>
-        <button disabled={loading} style={{ padding: "10px 16px" }}>
+        </div>
+        <Button disabled={loading} type="submit">
           {loading ? "Loguję..." : "Zaloguj"}
-        </button>
+        </Button>
       </form>
-      {err && <p style={{ color: "crimson", marginTop: 12 }}>{err}</p>}
+      {err && <p className="text-sm text-destructive">{err}</p>}
     </main>
-  );
+  )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,9 @@
 "use client";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 
 type LoginResponse = {
   ok?: boolean;
@@ -22,88 +25,93 @@ function isLoginResponse(value: unknown): value is LoginResponse {
 }
 
 export default function LoginPage() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const router = useRouter();
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const router = useRouter()
 
   async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (busy) return;
-    setBusy(true);
-    setError(null);
+    e.preventDefault()
+    if (busy) return
+    setBusy(true)
+    setError(null)
     try {
       const res = await fetch("/api/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),
-      });
+      })
 
       // bezpieczna próba odczytu JSON
       let data: unknown = null;
       try {
-        data = await res.json();
+        data = await res.json()
       } catch {
-        data = null;
+        data = null
       }
 
-      const payload = isLoginResponse(data) ? data : null;
+      const payload = isLoginResponse(data) ? data : null
 
       if (!res.ok || payload?.ok !== true) {
-        throw new Error(payload?.error || "Błędne dane");
+        throw new Error(payload?.error || "Błędne dane")
       }
-      router.push("/dashboard");
+      router.push("/dashboard")
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : null;
-      setError(message || "Błąd logowania");
+      const message = err instanceof Error ? err.message : null
+      setError(message || "Błąd logowania")
     } finally {
-      setBusy(false);
+      setBusy(false)
     }
   }
 
   return (
-    <main className="min-h-screen grid place-items-center px-4">
-      <form onSubmit={onSubmit} className="w-full max-w-sm rounded-2xl border border-neutral-200 p-6 shadow-sm">
-        <h1 className="mb-4 text-2xl font-semibold">Logowanie</h1>
+    <main className="grid min-h-screen place-items-center px-4">
+      <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4 rounded-2xl border border-neutral-200 p-6 shadow-sm">
+        <div>
+          <h1 className="text-2xl font-semibold">Logowanie</h1>
+          <p className="text-sm text-neutral-500">Zaloguj się do panelu firmowego.</p>
+        </div>
 
-        <label className="mb-2 block text-sm text-neutral-600" htmlFor="email">Email</label>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          inputMode="email"
-          autoComplete="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="mb-4 w-full rounded-lg border border-neutral-300 px-3 py-2 outline-none focus:border-neutral-500 focus:ring-2 focus:ring-neutral-200"
-          placeholder="email@domena.pl"
-          required
-        />
+        <div className="space-y-2">
+          <Label className="text-neutral-600" htmlFor="email">
+            Email
+          </Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            inputMode="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="email@domena.pl"
+            required
+          />
+        </div>
 
-        <label className="mb-2 block text-sm text-neutral-600" htmlFor="password">Hasło</label>
-        <input
-          id="password"
-          name="password"
-          type="password"
-          autoComplete="current-password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="mb-4 w-full rounded-lg border border-neutral-300 px-3 py-2 outline-none focus:border-neutral-500 focus:ring-2 focus:ring-neutral-200"
-          placeholder="••••••••"
-          required
-        />
+        <div className="space-y-2">
+          <Label className="text-neutral-600" htmlFor="password">
+            Hasło
+          </Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="••••••••"
+            required
+          />
+        </div>
 
-        <button
-          disabled={busy}
-          type="submit"
-          className="w-full rounded-lg bg-black px-4 py-2 text-white transition active:scale-[.99] disabled:opacity-60"
-        >
+        <Button disabled={busy} type="submit" className="w-full">
           {busy ? "Loguję…" : "Zaloguj"}
-        </button>
+        </Button>
 
-        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
       </form>
     </main>
-  );
+  )
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/30 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Zamknij</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+
+import { cn } from "@/lib/utils"
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className
+    )}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+        position === "popper" && "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-bottom-2 data-[state=open]:slide-in-from-bottom-2",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectPrimitive.ScrollUpButton className="flex cursor-default items-center justify-center py-1">
+        <ChevronUp className="h-4 w-4" />
+      </SelectPrimitive.ScrollUpButton>
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" && "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectPrimitive.ScrollDownButton className="flex cursor-default items-center justify-center py-1">
+        <ChevronDown className="h-4 w-4" />
+      </SelectPrimitive.ScrollDownButton>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,106 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn("bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-3 text-left align-middle text-xs font-medium uppercase text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn("p-3 align-top", className)} {...props} />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.16.2",
+        "@radix-ui/react-dialog": "^1.1.1",
+        "@radix-ui/react-label": "^2.1.1",
+        "@radix-ui/react-select": "^2.1.1",
+        "@radix-ui/react-slot": "^1.1.1",
         "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -223,6 +227,44 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1057,6 +1099,585 @@
         "@prisma/debug": "6.16.2"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1409,7 +2030,7 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1419,7 +2040,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -2045,6 +2666,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -2560,7 +3193,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2718,6 +3351,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -3653,6 +4292,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -5512,6 +6160,75 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -6496,6 +7213,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.1",
+    "@radix-ui/react-label": "^2.1.1",
+    "@radix-ui/react-select": "^2.1.1",
+    "@radix-ui/react-slot": "^1.1.1",
     "@prisma/client": "^6.16.2",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- add shadcn/ui primitives (button, input, label, textarea, select, table, dialog) and required radix dependencies
- rebuild admin user/order forms and tables around the shared components
- update monter flows, login screens, layout utilities and toasts to use the new UI primitives

## Testing
- `npm run build` *(fails: Next.js cannot download Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb43bb870832c840b855d1d10e44f